### PR TITLE
remove note on cg contrib list

### DIFF
--- a/CGCharter.html
+++ b/CGCharter.html
@@ -206,14 +206,6 @@
       "https://github.com/w3c/licenses/blob/master/CG-LICENSE.md">LICENSE</a> files.
     </p>
 
-    <p>
-      Note: this Community Group will not use a contrib mailing list for contributions 
-      since all contributions will be tracked via Github mechanisms 
-      (e.g. pull requests). For the same reason, the Community Group 
-      mailing list must not be used for making or discussing substantive contributions
-      to Specifications.
-    </p>
-    
     <h2 id="transparency">
       Transparency
     </h2>


### PR DESCRIPTION
@ianbjacobs
Removed the paragraph on not using the cg contrib list and not doing contributions on mail list (when using GitHub).  that latter sentence was being dropped by users of the template.  it's not necessary so making the template consistent with use.
