### PR TITLE
[CG Charter] test suite paragraph was for WGs

### DIFF
--- a/CGCharter.html
+++ b/CGCharter.html
@@ -116,15 +116,15 @@
         Test Suites and Other Software
       </h3>
     
-      <p class="remove">{TBD: State whether test suites or any other software 
-       will be created for any Specifications and list the relevant licenses. 
-       For information about contributions to W3C test suites, please see 
-       <a href="http://testthewebforward.org/">Test the Web Forward</a>,
-       and take note of the <a href="http://www.w3.org/2004/10/27-testcases">W3C's
-       test suite contribution policy</a> and 
-       <a href="http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright.html">licenses
-       for W3C test suites></a>. If there are no plans to create a test suite 
-       or other software, please state that.}</p> 
+      <p class="remove">{TBD: If there are no plans to create a test suite 
+       or other software, please state that and remove the following paragraph. If
+       Github is not being used, then indicate where the license information is.}
+      </p>
+      <p>
+        The group MAY produce test suites to support the Specifications.  Please see the 
+        <a href="https://github.com/w3c/webvr/blob/gh-pages/LICENSE.md">GitHub LICENSE</a> file for
+        test suite contribution licensing information.
+      </p> 
     
     <h2 id="liaisons">
       Dependencies or Liaisons


### PR DESCRIPTION
@ianbjacobs @wseltzer
The test suite section for the CG Charter template points to a page that is only about WGs.  It includes the 2 ways to include test suites in a WG (either as part of the spec or not) and also directly refers to the W3C patent policy.  It's not at all relevant to CGs. 

It would be better just to point to the GitHub LICENSE.md file if in GitHub.

 I followed links in that material until I found the W3C license used and proposed putting that in the LICENSE.md file for the WebVR CG.   That's a separate change I'll suggest in the W3C LICENSE.md file for CGs.
