### PR TITLE
[CGCharter] had link to WebVR CG LICENSE.md

### DIFF
--- a/CGCharter.html
+++ b/CGCharter.html
@@ -118,11 +118,12 @@
     
       <p class="remove">{TBD: If there are no plans to create a test suite 
        or other software, please state that and remove the following paragraph. If
-       Github is not being used, then indicate where the license information is.}
+       Github is not being used, then indicate where the license information is.
+       If GitHub is being used link to your LICENSE.md file in the next paragraph.}
       </p>
       <p>
         The group MAY produce test suites to support the Specifications.  Please see the 
-        <a href="https://github.com/w3c/webvr/blob/gh-pages/LICENSE.md">GitHub LICENSE</a> file for
+        GitHub LICENSE file for
         test suite contribution licensing information.
       </p> 
     
@@ -198,7 +199,7 @@
       or by adding a comment to an existing issue.
     </p>
 
-    <p>
+    <p id="githublicense">
       All Github repositories attached to the Community Group must contain a
       copy of the 
       <a href="https://github.com/w3c/licenses/blob/master/CG-CONTRIBUTING.md">CONTRIBUTING</a>


### PR DESCRIPTION
changed it to link to the license section of the charter (since we don't know where they will put their charter in their GitHub repo)
