### PR TITLE
Update link to Code of Conduct in the CG Charter

### DIFF
--- a/CGCharter.html
+++ b/CGCharter.html
@@ -158,8 +158,8 @@
     </p>
 
     <p>
-      The <a href="https://www.w3.org/Consortium/cepc/">W3C Code of
-      Ethics and Professional Conduct</a> applies to participation in
+      The <a href="https://www.w3.org/policies/code-of-conduct/">W3C Code of
+      Conduct</a> applies to participation in
       this group.
     </p>
 


### PR DESCRIPTION
The CG charter was still referring to the CEPC, I've updated the link and the label. 